### PR TITLE
Restore the example HTML typo

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -31,7 +31,7 @@ With Super it becomes impossible to output malformed HTML as the result of templ
 
 `page.html`
 ```html
-<h1>Oops!</h1>
+<h1>Oops!<h1>
 ```
 
 ***`shell`***


### PR DESCRIPTION
If I understand well the content, the purpose of this HTML example is to illustrate a typo error, in order to be consistent with the following console output.

So this commit restores the typo...