### PR TITLE
Fix `build.zig.zon` in documentation.

### DIFF
--- a/content/documentation/index.md
+++ b/content/documentation/index.md
@@ -35,8 +35,10 @@ Your website only needs the following two files to get started:
     .name = "sample website",
     .version = "0.0.0",
     .dependencies = .{
-        .url = "git+https://github.com/kristoff-it/zine#v0.2.0",
-        .hash = "1220781f118454bbc87d7efbd244b4d1ef029e76a6113ddf4752a6f3cd85879dbb3b",
+        .zine = .{
+            .url = "git+https://github.com/kristoff-it/zine#v0.2.0",
+            .hash = "1220781f118454bbc87d7efbd244b4d1ef029e76a6113ddf4752a6f3cd85879dbb3b",
+        },
     },
     .paths = .{"."},
 }


### PR DESCRIPTION
The `build.zig.zon` file should have a property named `zine`, which is then a struct with `url` and `hash` fields.