### PR TITLE
Fix nvim config for superhtml

### DIFF
--- a/content/docs/editors/neovim.smd
+++ b/content/docs/editors/neovim.smd
@@ -102,7 +102,7 @@ formatters = {
     inherit = false,
     command = 'superhtml',
     stdin = true,
-    args = { 'fmt', '--stdin' },
+    args = { 'fmt', '--stdin-super' },
   },
   ziggy = {
     inherit = false,


### PR DESCRIPTION
Formatting fails when using --stdin on superhtml files due to void elements (and probably other things too). 