### PR TITLE
Editor support for GNOME Builder

### DIFF
--- a/content/docs/editors/index.smd
+++ b/content/docs/editors/index.smd
@@ -53,6 +53,9 @@ If you encounter issues while setting up your editor, [join the community](/comm
 
 Make sure to have all the CLI tools available in your `PATH` to enable LSP support.
 
+## GNOME Builder
+[SuperBuilder](https://github.com/Shardion/superbuilder) provides extensions for SuperHTML and SuperMD.
+
 ## Other editors
 Any editor that supports Tree Sitter for syntax highlighting and the Language Server Protocol can be setup to support Ziggy, SuperMD, and SuperHTML.
 


### PR DESCRIPTION
Hello!! I made [SuperBuilder,](https://github.com/shardion/superbuilder) which provides SuperHTML and SuperMD extensions for [GNOME Builder.](https://developer.gnome.org/documentation/introduction/builder.html) This PR adds them to `content/docs/editors/index.smd`.