### PR TITLE
Fix SuperMD examples that are broken because they contain spaces

### DIFF
--- a/content/docs/supermd/scripty.smd
+++ b/content/docs/supermd/scripty.smd
@@ -183,7 +183,7 @@ Allows giving an id and attributes to a heading element.
 
 Example:
 ```markdown
-# [Title]($heading.id('foo').attrs('bar', 'baz'))
+# [Title]($heading.id('foo').attrs('bar','baz'))
 ```
 
 This will be rendered by SuperHTML as:
@@ -197,7 +197,7 @@ Allows giving an id and attributes to some text.
 
 Example:
 ```markdown
-Hello [World]($text.id('foo').attrs('bar', 'baz'))!
+Hello [World]($text.id('foo').attrs('bar','baz'))!
 ```
 
 This will be rendered by SuperHTML as:
@@ -406,7 +406,7 @@ Allows giving an id and attributes to a heading element.
 
 Example:
 ```markdown
-# [Title]($heading.id('foo').attrs('bar', 'baz'))
+# [Title]($heading.id('foo').attrs('bar','baz'))
 ```
 
 This will be rendered by SuperHTML as:
@@ -442,17 +442,17 @@ Sets the width and/or height of the image.
 
 When both dimensions are non-zero, the image will be resized to exactly those dimensions:
 ```markdown
-[Image caption]($image.asset('example.jpg').size(800, 600))
+[Image caption]($image.asset('example.jpg').size(800,600))
 ```
 
 To specify width while maintaining aspect ratio, set height to 0:
 ```markdown
-[Image caption]($image.asset('example.jpg').size(800, 0))
+[Image caption]($image.asset('example.jpg').size(800,0))
 ```
 
 To specify height while maintaining aspect ratio, set width to 0:
 ```markdown
-[Image caption]($image.asset('example.jpg').size(0, 600))
+[Image caption]($image.asset('example.jpg').size(0,600))
 ```
 
 
@@ -716,7 +716,7 @@ Allows giving an id and attributes to some text.
 
 Example:
 ```markdown
-Hello [World]($text.id('foo').attrs('bar', 'baz'))!
+Hello [World]($text.id('foo').attrs('bar','baz'))!
 ```
 
 This will be rendered by SuperHTML as:


### PR DESCRIPTION
A few of the examples in the SuperMD Scripty docs have spaces in invalid places, which causes the mysterious `[no_alt_in_links]` and `[scripty] truncated expression` errors. For the image and code asset examples, it causes no error and just outputs the literal text instead (weird, probably a bug).