### PR TITLE
Add option for Helix to recognise default .ziggy-schema file

### DIFF
--- a/content/docs/editors/helix.smd
+++ b/content/docs/editors/helix.smd
@@ -69,7 +69,7 @@ name = "ziggy_schema"
 scope = "text.ziggy_schema"
 roots = []
 injection-regex = "ziggy-schema|zgy-schema"
-file-types = ["ziggy-schema", "zgy-schema"]
+file-types = ["ziggy-schema", "zgy-schema", { glob = ".ziggy-schema" }]
 comment-token = "///"
 indent = { tab-width = 4, unit = "    " }
 formatter = { command = "ziggy" , args = ["fmt", "-", "--type", "schema"] }


### PR DESCRIPTION
`helix` may not recognise the language of the `.ziggy-schema` file created with `zine init` by default (it definitely doesn't recognise it for me, building the editor from source), resulting in no syntax highlighting or LSP; this `glob` table fixes it (as described [here](https://docs.helix-editor.com/languages.html#file-type-detection-and-the-file-types-key))