### PR TITLE
log: add note about cross-platform diff tool

### DIFF
--- a/content/log.smd
+++ b/content/log.smd
@@ -32,13 +32,19 @@ You can [subscribe to this page via RSS]($link.alternative("rss")).
 > ># [More examples of useful diffing commands]($block.collapsible(false))
 > > Normal diffing is line based, but occasionally you will want
 > > to find more easily which word has changed within a line.
-> > 
+> >
 > > This command highlights individual words:
 > > - `git diff --word-diff=color --no-index new old`
-> > 
+> >
 > > This command highlights individual characters, useful for
 > > quickly detecting whitespace changes:
 > > - `git diff --no-index --word-diff-regex=. new old`
+> >
+> > [`delta`](https://dandavison.github.io/delta/introduction.html) is a diff
+> > tool that is cross-platform, and supports word-diff and syntax highlighting
+> > by default (You do not need to configure it for git to use it as a
+> > standalone diff tool):
+> > - `delta new old`
 
 
 []($section.id('v0.13.0').data('date','2026-07-19'))


### PR DESCRIPTION
Delta is a cross-platform diff tool that supports word-diff and syntax highlighting.

Specifically, it supports Windows, which I don't think the other suggested commands do (except for `git`, but that one is a bit clunky to use, since there are extra flags to remember).

Note: I saw that the order for all the commands is `new` `old`. Is that correct? Shouldn't it be `old` `new`? (If that is a typo, I can fix it in this PR)